### PR TITLE
Use es5 imports in typings files

### DIFF
--- a/src/typings/jupyter-js-widgets/jupyter-js-widgets.d.ts
+++ b/src/typings/jupyter-js-widgets/jupyter-js-widgets.d.ts
@@ -5,15 +5,13 @@
 
 
 declare module "jupyter-js-widgets" {
-  import {
-    IKernelIOPubCommOpenMessage, IKernelMessage
-  } from 'jupyter-js-services';
+  import services = require('jupyter-js-services');
 
   export class ManagerBase<T> {
-    display_view(msg: IKernelMessage, view: Backbone.View<Backbone.Model>, options: any): T;
-    handle_comm_open(comm: shims.services.Comm, msg: IKernelIOPubCommOpenMessage): Promise<Backbone.Model>;
+    display_view(msg: services.IKernelMessage, view: Backbone.View<Backbone.Model>, options: any): T;
+    handle_comm_open(comm: shims.services.Comm, msg: services.IKernelIOPubCommOpenMessage): Promise<Backbone.Model>;
     // how do I say msg is an IKernelMessage from 'jupyter-js-services'?
-    display_model(msg: IKernelMessage, model: Backbone.Model, options: any): Promise<T>;
+    display_model(msg: services.IKernelMessage, model: Backbone.Model, options: any): Promise<T>;
     get_model(id: string): Promise<Backbone.Model>;
   }
 


### PR DESCRIPTION
ES6 import syntax handling was added in TS 1.7 but TypeDoc is using 1.6.
